### PR TITLE
Migrated nativescript starter template to individual component plugins

### DIFF
--- a/customers/customer-list/customer-list.component.ts
+++ b/customers/customer-list/customer-list.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, ViewChild, ChangeDetectorRef } from "@angular/core";
 import { ObservableArray } from "data/observable-array";
 import { RouterExtensions } from "nativescript-angular/router";
-import { ListViewEventData, ListViewLinearLayout, RadListView } from "nativescript-pro-ui/listview";
-import { DrawerTransitionBase, SlideInOnTopTransition } from "nativescript-pro-ui/sidedrawer";
-import { RadSideDrawerComponent } from "nativescript-pro-ui/sidedrawer/angular";
+import { ListViewEventData, ListViewLinearLayout, RadListView } from "nativescript-ui-listview";
+import { DrawerTransitionBase, SlideInOnTopTransition } from "nativescript-ui-sidedrawer";
+import { RadSideDrawerComponent } from "nativescript-ui-sidedrawer/angular";
 import { isAndroid, isIOS } from "platform";
 
 import { EventData, View } from "tns-core-modules/ui/core/view/view";

--- a/customers/customers.module.ts
+++ b/customers/customers.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
 import { NativeScriptCommonModule } from "nativescript-angular/common";
 import { NativeScriptFormsModule } from "nativescript-angular/forms";
-import { NativeScriptUIListViewModule } from "nativescript-pro-ui/listview/angular";
+import { NativeScriptUIListViewModule } from "nativescript-ui-listview/angular";
 
 import { SharedModule } from "../shared/shared.module";
 import { CustomerDetailEditComponent } from "./customer-detail-edit/customer-detail-edit.component";

--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
         "base-64": "^0.1.0",
         "nativescript-angular": "~5.1.0",
         "nativescript-imagepicker": "~4.0.1",
-        "nativescript-localstorage": "^1.1.5",
-        "nativescript-pro-ui": "~3.3.0",
+        "nativescript-localstorage": "^1.1.5",        
         "nativescript-theme-core": "~1.0.4",
+        "nativescript-ui-listview": "^3.5.4",
+        "nativescript-ui-sidedrawer": "^3.5.2",
         "reflect-metadata": "~0.1.10",
         "tns-core-modules": "~3.4.0",
         "zone.js": "~0.8.18"

--- a/shared/shared.module.ts
+++ b/shared/shared.module.ts
@@ -1,6 +1,6 @@
 import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
 import { NativeScriptModule } from "nativescript-angular/nativescript.module";
-import { NativeScriptUISideDrawerModule } from "nativescript-pro-ui/sidedrawer/angular";
+import { NativeScriptUISideDrawerModule } from "nativescript-ui-sidedrawer/angular";
 
 import { SideDrawerComponent } from "./side-drawer/side-drawer.component";
 

--- a/shared/side-drawer/side-drawer.component.ts
+++ b/shared/side-drawer/side-drawer.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from "@angular/core";
 import { RouterExtensions } from "nativescript-angular/router";
-import { RadSideDrawerComponent } from "nativescript-pro-ui/sidedrawer/angular";
+import { RadSideDrawerComponent } from "nativescript-ui-sidedrawer/angular";
 import { ItemEventData } from "ui/list-view";
 
 import { navigationCancelingError } from "@angular/router/src/shared";


### PR DESCRIPTION
Migrated nativescript starter template from nativescript-pro-ui to use individual component (Sidedrawer and listView) level plugins.