### PR TITLE
Anil/adas 2291 spinner max rec count

### DIFF
--- a/customers/customer-list/customer-list.component.ts
+++ b/customers/customer-list/customer-list.component.ts
@@ -306,18 +306,18 @@ export class CustomerListComponent implements OnInit {
             this._skipRec = params.skip;
 
             this._recCount = this._customers.length;
+            const listView: RadListView = args.object;
 
             // If max record count is available/specified in the settings or if the number of records
             //  loaded in client reaches to max count then send an alert
             if (params.maxRecCount && (((this.scrollCount) * (params.pageSize) === params.maxRecCount)
-                && (this._recCount) === (params.maxRecCount))) {
-                listView.loadOnDemandMode = ListViewLoadOnDemandMode[ListViewLoadOnDemandMode.None];
+                && (this._recCount) === (params.maxRecCount))) {                
                 this._isLoading = false;
-                args.object.notifyLoadOnDemandFinished();
+                args.object.notifyLoadOnDemandFinished();                
                 alert("Reached max size. Increase limit.");
+                listView.loadOnDemandMode = ListViewLoadOnDemandMode[ListViewLoadOnDemandMode.None];
             } else {
-
-                const listView: RadListView = args.object;
+                
                 this._customerService.load(params)
                     .finally(() => {
                         this._isLoading = false;

--- a/customers/customer-list/customer-list.component.ts
+++ b/customers/customer-list/customer-list.component.ts
@@ -311,6 +311,7 @@ export class CustomerListComponent implements OnInit {
             //  loaded in client reaches to max count then send an alert
             if (params.maxRecCount && (((this.scrollCount) * (params.pageSize) === params.maxRecCount)
                 && (this._recCount) === (params.maxRecCount))) {
+                listView.loadOnDemandMode = ListViewLoadOnDemandMode[ListViewLoadOnDemandMode.None];
                 this._isLoading = false;
                 args.object.notifyLoadOnDemandFinished();
                 alert("Reached max size. Increase limit.");


### PR DESCRIPTION
After a max record count is reached, setting the loadOnDemandMode to 'None' such that user cannot perform any incremental scrolling in the listView.

Actual issue is resolved. i.e., after reaching the maxRecCount, spinner is not visible and further reading of records is blocked. 
However, there is an issue with respect to pulldowntorefresh. i.e., after reaching max record count and performing pull down to refresh operation in the list view, list view does not bring all records. This because incremental scrolling (loadOnDemandMode) is not triggered even though loadOnDemandMode is Auto. This could be because of NativeScript issue #[595](https://github.com/telerik/nativescript-ui-feedback/issues/595) which is due for NativeScript 4.2 release.

Please note that everything works fine in Android.